### PR TITLE
chore: make the `li` elements look more consistent

### DIFF
--- a/resets.css
+++ b/resets.css
@@ -130,6 +130,8 @@ ol,
 ul,
 menu {
   list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 /* Make elements with the HTML hidden attribute stay hidden by default */


### PR DESCRIPTION
Make the `li` elements more consistent by removing their default styles, padding and margins.